### PR TITLE
Clarify installing/JIT

### DIFF
--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -151,7 +151,7 @@ export default function Links() {
                  className="flex items-center p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors">
                 <div className="text-2xl mr-4">🐬</div>
                 <div>
-                  <h3 className="font-semibold text-blue-900 dark:text-blue-300">DolphinIOS</h3>
+                  <h3 className="font-semibold text-blue-900 dark:text-blue-300">DolphiniOS</h3>
                   <p className="text-sm text-blue-700 dark:text-blue-400">
                     iOS port of Dolphin emulator that inspired iCube
                   </p>

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -29,13 +29,15 @@ export default function Support() {
 
               <div className="border-b border-gray-200 dark:border-gray-700 pb-4">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-                  How do I install iCube (sideload)?
+                  How do I install iCube (sideloaded)?
                 </h3>
                 <p className="text-gray-600 dark:text-gray-300">
                   iCube is distributed via sideloading for iOS and tvOS. <br /> We recommend using{' '}
+                  <a href="https://sidestore.io" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">SideStore</a>{' '}
+                  to install the app on your iOS/iPadOS device. To install on your tvOS device, use{' '}
                   <a href="https://sideloadly.io" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">Sideloadly</a>{' '}
-                  to install the app on your device. For enabling JIT on Apple TV, we recommend{' '}
-                  <a href="https://apps.apple.com/us/app/stikdebug/id6744045754" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">StikDebug</a>.
+                  . To enable JIT on iOS/iPadOS, we recommend using{' '}
+                  <a href="https://apps.apple.com/us/app/stikdebug/id6744045754" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">StikDebug</a>{' '}.
                 </p>
               </div>
 
@@ -56,7 +58,7 @@ export default function Support() {
                 </h3>
                 <p className="text-gray-600 dark:text-gray-300">
                   iCube requires iOS 16.0 or later for iPhone and iPad, and tvOS 17.0 or later for Apple TV.
-                  For optimal performance, we recommend newer devices like iPhone 16 or later,
+                  For optimal JIT-less performance, we recommend newer devices like iPhone 16 or later,
                   iPad (7th generation) or later, and Apple TV 4K (4th generation).
                 </p>
               </div>

--- a/src/components/DownloadSection.tsx
+++ b/src/components/DownloadSection.tsx
@@ -11,7 +11,16 @@ export type DownloadSectionProps = {
 
 const DefaultDescription = () => (
   <p className="text-gray-600 dark:text-gray-300 mb-6">
-    iCube isn’t on the App Store. You can sideload it from the sources below. We recommend
+    iCube isn’t on the App Store. You can sideload it from the sources below. We recommend using
+    <a
+      href="https://sidestore.io"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 dark:text-blue-400 hover:underline ml-1"
+    >
+      SideStore
+    </a>
+    to install on iOS/iPadOS, using
     <a
       href="https://sideloadly.io"
       target="_blank"
@@ -20,7 +29,7 @@ const DefaultDescription = () => (
     >
       Sideloadly
     </a>
-    for installing on iOS/tvOS, and for Apple TV JIT we recommend
+    to install on tvOS, and using
     <a
       href="https://apps.apple.com/us/app/stikdebug/id6744045754"
       target="_blank"
@@ -29,7 +38,7 @@ const DefaultDescription = () => (
     >
       StikDebug
     </a>
-    .
+    to enable JIT on iOS/iPadOS.
   </p>
 );
 

--- a/src/components/DownloadSection.tsx
+++ b/src/components/DownloadSection.tsx
@@ -20,7 +20,7 @@ const DefaultDescription = () => (
     >
       SideStore
     </a>
-    to install on iOS/iPadOS, using
+     for installing on iOS/iPadOS, using
     <a
       href="https://sideloadly.io"
       target="_blank"
@@ -29,7 +29,7 @@ const DefaultDescription = () => (
     >
       Sideloadly
     </a>
-    to install on tvOS, and using
+     for installing on tvOS, and using
     <a
       href="https://apps.apple.com/us/app/stikdebug/id6744045754"
       target="_blank"
@@ -38,7 +38,7 @@ const DefaultDescription = () => (
     >
       StikDebug
     </a>
-    to enable JIT on iOS/iPadOS.
+     to enable JIT on iOS/iPadOS.
   </p>
 );
 

--- a/src/components/DownloadSection.tsx
+++ b/src/components/DownloadSection.tsx
@@ -18,27 +18,27 @@ const DefaultDescription = () => (
       rel="noopener noreferrer"
       className="text-blue-600 dark:text-blue-400 hover:underline ml-1"
     >
-      SideStore 
+      SideStore
     </a>
-    to install on iOS/iPadOS, using
+    {' '}to install on iOS/iPadOS, using
     <a
       href="https://sideloadly.io"
       target="_blank"
       rel="noopener noreferrer"
       className="text-blue-600 dark:text-blue-400 hover:underline ml-1"
     >
-      Sideloadly 
+      Sideloadly
     </a>
-    to install on tvOS, and using
+    {' '}to install on tvOS, and using
     <a
       href="https://apps.apple.com/us/app/stikdebug/id6744045754"
       target="_blank"
       rel="noopener noreferrer"
       className="text-blue-600 dark:text-blue-400 hover:underline ml-1"
     >
-      StikDebug 
+      StikDebug
     </a>
-    to enable JIT on iOS/iPadOS.
+    {' '}to enable JIT on iOS/iPadOS.
   </p>
 );
 

--- a/src/components/DownloadSection.tsx
+++ b/src/components/DownloadSection.tsx
@@ -18,27 +18,27 @@ const DefaultDescription = () => (
       rel="noopener noreferrer"
       className="text-blue-600 dark:text-blue-400 hover:underline ml-1"
     >
-      SideStore
+      SideStore 
     </a>
-     for installing on iOS/iPadOS, using
+    to install on iOS/iPadOS, using
     <a
       href="https://sideloadly.io"
       target="_blank"
       rel="noopener noreferrer"
       className="text-blue-600 dark:text-blue-400 hover:underline ml-1"
     >
-      Sideloadly
+      Sideloadly 
     </a>
-     for installing on tvOS, and using
+    to install on tvOS, and using
     <a
       href="https://apps.apple.com/us/app/stikdebug/id6744045754"
       target="_blank"
       rel="noopener noreferrer"
       className="text-blue-600 dark:text-blue-400 hover:underline ml-1"
     >
-      StikDebug
+      StikDebug 
     </a>
-     to enable JIT on iOS/iPadOS.
+    to enable JIT on iOS/iPadOS.
   </p>
 );
 


### PR DESCRIPTION
### **User description**
Also fixes DolphiniOS typo, fixes spacing, and recommends SideStore because it's peak.
Squash when merging please.
For whatever reason, iconURL doesn't populate the source icon anymore (only the app icon), though it did when I was testing earlier. 🤷🏻‍♂️


___

### **PR Type**
Documentation


___

### **Description**
- Update installation instructions to recommend SideStore for iOS/iPadOS

- Clarify JIT enabling instructions for different platforms

- Fix DolphinIOS typo to DolphiniOS

- Improve wording and formatting consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Installation Guide"] --> B["SideStore for iOS/iPadOS"]
  A --> C["Sideloadly for tvOS"]
  A --> D["StikDebug for JIT"]
  B --> E["Updated Instructions"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Fix DolphiniOS name typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/links/page.tsx

- Fix typo from "DolphinIOS" to "DolphiniOS" in the links page


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/icube-emu.github.io/pull/3/files#diff-785b7d15361a50dcf5bc5425d672c4d187aafe17da3b1e2c57e801f24f4b452f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Update installation and JIT guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/support/page.tsx

<ul><li>Update installation question to use "sideloaded" instead of "sideload"<br> <li> Add SideStore recommendation for iOS/iPadOS installation<br> <li> Clarify JIT enabling instructions for different platforms<br> <li> Update performance recommendation to mention "JIT-less performance"</ul>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/icube-emu.github.io/pull/3/files#diff-f95e9479508d3ad2b947c7e89ff47fd0ff82cd3e98b4d3d0e2eb685b42572454">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DownloadSection.tsx</strong><dd><code>Restructure download instructions with SideStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/DownloadSection.tsx

<ul><li>Add SideStore as recommended tool for iOS/iPadOS installation<br> <li> Restructure installation instructions for better clarity<br> <li> Update JIT enabling guidance to specify iOS/iPadOS platforms<br> <li> Improve text formatting and spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/icube-emu.github.io/pull/3/files#diff-ad0e9ea341e60fe1a6cea9116dba929c3b7402b8347801a71e568aa7103249a7">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

